### PR TITLE
Revert PR#10

### DIFF
--- a/Grid.cs
+++ b/Grid.cs
@@ -35,8 +35,7 @@ namespace fantasticOctoWaddle
 
                     // set each Cell Objects location
                     // Setting this now since we are already iterating through the array
-                    // Add 25 to the column to move it down and allow for the Menu Strip
-                    board[row, col].Location = new Point(row * 25, 25 + col * 25);
+                    board[row, col].Location = new Point(row * 25, col * 25);
                 }
             }
 


### PR DESCRIPTION
Reverting the changes to Grid.cs from PR 10.  25 pts were added to the Point y coordinates. Reverted because decision to use a panel removes that requirement.